### PR TITLE
Save and quit

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -176,6 +176,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gRestoreRBAValues",
     "gSkipSaveConfirmation",
     "gAutosave",
+    "gSaveAndQuit",
     "gDisableCritWiggle",
     "gChestSizeDependsStoneOfAgony",
     "gSkipArrowAnimation",

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -907,6 +907,11 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Targetable Hookshot Reticle", "gHookshotableReticle", true, false);
             UIWidgets::Tooltip("Use a different color when aiming at hookshotable collision");
 
+            UIWidgets::PaddedEnhancementCheckbox("Ask to continue playing after saving", "gSaveAndQuit", true, false);
+            UIWidgets::Tooltip(
+                "The save dialog from the pause menu will ask you to continue playing after you select Yes or No.\n"
+                "Pressing B or Start on the save prompt will close the pause menu without displaying the extra screen.");
+
             ImGui::EndMenu();
         }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
@@ -9,7 +9,7 @@ void KaleidoScope_UpdatePrompt(PlayState* play) {
     s16 step;
     bool dpad = CVarGetInteger("gDpadPause", 0);
 
-    if (((pauseCtx->state == 7) && (pauseCtx->unk_1EC == 1)) || (pauseCtx->state == 0xE) || (pauseCtx->state == 0x10)) {
+    if (((pauseCtx->state == 7) && (pauseCtx->unk_1EC == 1 || pauseCtx->unk_1EC == 7)) || (pauseCtx->state == 0xE) || (pauseCtx->state == 0x10)) {
         if ((pauseCtx->promptChoice == 0) && ((relStickX >= 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)))) {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             pauseCtx->promptChoice = 4;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1595,9 +1595,17 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
 
         gSPVertex(POLY_KAL_DISP++, &pauseCtx->saveVtx[60], 32, 0);
 
-        if (((pauseCtx->state == 7) && (pauseCtx->unk_1EC < 4)) || (pauseCtx->state == 0xE)) {
-            POLY_KAL_DISP =
-                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSavePromptTexs[gSaveContext.language], 152, 16, 0);
+        if (((pauseCtx->state == 7) &&
+             (pauseCtx->unk_1EC < 4 || pauseCtx->unk_1EC == 7 ||
+              (CVarGetInteger("gSaveAndQuit", 0) && (pauseCtx->unk_1EC == 5 || pauseCtx->unk_1EC == 8)))) ||
+            (pauseCtx->state == 0xE)) {
+            if (pauseCtx->unk_1EC == 5 || pauseCtx->unk_1EC == 7 || pauseCtx->unk_1EC == 8) {
+                POLY_KAL_DISP =
+                    KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sContinuePromptTexs[gSaveContext.language], 152, 16, 0);
+            } else {
+                POLY_KAL_DISP =
+                    KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSavePromptTexs[gSaveContext.language], 152, 16, 0);
+            }
 
             gDPSetCombineLERP(POLY_KAL_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0, TEXEL0,
                               0, PRIMITIVE, 0);
@@ -4049,6 +4057,12 @@ void KaleidoScope_Update(PlayState* play)
                 case 1:
                     if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
                         if (pauseCtx->promptChoice != 0) {
+                            if (CVarGetInteger("gSaveAndQuit", 0)) {
+                                pauseCtx->promptChoice = 0;
+                                Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+                                pauseCtx->unk_1EC = 7;
+                                break;
+                            }
                             Interface_SetDoAction(play, DO_ACTION_NONE);
                             gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                                 gSaveContext.buttonStatus[3] = BTN_ENABLED;
@@ -4086,6 +4100,10 @@ void KaleidoScope_Update(PlayState* play)
                 case 4:
                     if (CHECK_BTN_ALL(input->press.button, BTN_B) || CHECK_BTN_ALL(input->press.button, BTN_A) ||
                         CHECK_BTN_ALL(input->press.button, BTN_START) || (--D_8082B25C == 0)) {
+                        if (CVarGetInteger("gSaveAndQuit", 0)) {
+                            pauseCtx->unk_1EC = 7;
+                            break;
+                        }
                         Interface_SetDoAction(play, DO_ACTION_NONE);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_ENABLED;
@@ -4134,6 +4152,46 @@ void KaleidoScope_Update(PlayState* play)
                         pauseCtx->namedItem = PAUSE_ITEM_NONE;
                         pauseCtx->unk_1E4 = 0;
                         pauseCtx->unk_204 = -434.0f;
+                    }
+                    break;
+
+                // 7 and 8 are used by "Prompt to quit after saving" enhancement
+                case 7:
+                    if (CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->press.button, BTN_B) ||
+                        CHECK_BTN_ALL(input->press.button, BTN_START)) {
+                        if (pauseCtx->promptChoice == 0 || CHECK_BTN_ALL(input->press.button, BTN_B)) {
+                            Interface_SetDoAction(play, DO_ACTION_NONE);
+                            gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
+                                gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                            gSaveContext.buttonStatus[5] = gSaveContext.buttonStatus[6] = gSaveContext.buttonStatus[7] =
+                                gSaveContext.buttonStatus[8] = BTN_ENABLED;
+                            gSaveContext.unk_13EA = 0;
+                            Interface_ChangeAlpha(50);
+                            pauseCtx->unk_1EC = 5;
+                            WREG(2) = -6240;
+                            YREG(8) = pauseCtx->unk_204;
+                            func_800F64E0(0);
+                        } else {
+                            Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0,
+                                                   &D_801333E8);
+                            pauseCtx->unk_1EC = 8;
+                        }
+                    }
+                    break;
+
+                case 8:
+                    if (interfaceCtx->unk_244 != 255) {
+                        interfaceCtx->unk_244 += 10;
+                        if (interfaceCtx->unk_244 >= 255) {
+                            interfaceCtx->unk_244 = 255;
+                            pauseCtx->state = 0;
+                            R_UPDATE_RATE = 3;
+                            R_PAUSE_MENU_MODE = 0;
+                            func_800981B8(&play->objectCtx);
+                            func_800418D0(&play->colCtx, play);
+                            play->state.running = 0;
+                            SET_NEXT_GAMESTATE(&play->state, Opening_Init, OpeningContext);
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
Adds an enhancement option under Enhancements > Gameplay that changes the save prompt to also ask to continue playing like the Game Over screen does. Selecting Yes will close the pause menu as normal, and No will return to the title screen like on the Game Over screen.

If you want to continue without saving, pressing B or Start on the save prompt will still immediately close the pause menu.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732098.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732101.zip)
  - [soh-linux-performance.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732104.zip)
  - [soh-mac.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732106.zip)
  - [soh-switch.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732107.zip)
  - [soh-wiiu.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732109.zip)
  - [soh-windows.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1132732111.zip)
<!--- section:artifacts:end -->