### PR TITLE
Catch Poes with bottles

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -79,6 +79,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gFasterHeavyBlockLift",
     "gNoForcedNavi",
     "gSkulltulaFreeze",
+    "gMMPoeBottling",
     "gMMBunnyHood",
     "gAdultBunnyHood",
     "gFastChests",

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -612,6 +612,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Allows the bunny hood to be equipped normally from the pause menu as adult.");
                 UIWidgets::PaddedEnhancementCheckbox("Mask Select in Inventory", "gMaskSelect", true, false);
                 UIWidgets::Tooltip("After completing the mask trading sub-quest, press A and any direction on the mask slot to change masks");
+                UIWidgets::PaddedEnhancementCheckbox("Catch Poes with a bottle", "gMMPoeBottling", true, false);
+                UIWidgets::Tooltip("Catch Poes by swinging an empty bottle at them instead of from a text box like you can in Majora's Mask.");
                 UIWidgets::PaddedEnhancementCheckbox("Nuts explode bombs", "gNutsExplodeBombs", true, false);
                 UIWidgets::Tooltip("Makes nuts explode bombs, similar to how they interact with bombchus. This does not affect bombflowers.");
                 UIWidgets::PaddedEnhancementCheckbox("Equip Multiple Arrows at Once", "gSeparateArrows", true, false);
@@ -886,7 +888,7 @@ void DrawEnhancementsMenu() {
                 OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BLUE_FIRE_ARROWS);
             static const char* forceEnableBlueFireArrowsText =
                 "This setting is forcefully enabled because a savefile\nwith \"Blue Fire Arrows\" is loaded.";
-            UIWidgets::PaddedEnhancementCheckbox("Blue Fire Arrows", "gBlueFireArrows", true, false, 
+            UIWidgets::PaddedEnhancementCheckbox("Blue Fire Arrows", "gBlueFireArrows", true, false,
                 forceEnableBlueFireArrows, forceEnableBlueFireArrowsText, UIWidgets::CheckboxGraphics::Checkmark);
             UIWidgets::Tooltip("Allows Ice Arrows to melt red ice.\nMay require a room reload if toggled during gameplay.");
 
@@ -895,7 +897,7 @@ void DrawEnhancementsMenu() {
                 OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SUNLIGHT_ARROWS);
             static const char* forceEnableSunLightArrowsText =
                 "This setting is forcefully enabled because a savefile\nwith \"Sunlight Arrows\" is loaded.";
-            UIWidgets::PaddedEnhancementCheckbox("Sunlight Arrows", "gSunlightArrows", true, false, 
+            UIWidgets::PaddedEnhancementCheckbox("Sunlight Arrows", "gSunlightArrows", true, false,
                 forceEnableSunLightArrows, forceEnableSunLightArrowsText, UIWidgets::CheckboxGraphics::Checkmark);
             UIWidgets::Tooltip("Allows Light Arrows to activate sun switches.\nMay require a room reload if toggled during gameplay.");
 
@@ -1090,8 +1092,8 @@ void DrawEnhancementsMenu() {
                                 "Fixes an incorrect calculation that acted like water underneath ground was above it.");
             UIWidgets::PaddedEnhancementCheckbox("Fix Bush Item Drops", "gBushDropFix", true, false);
             UIWidgets::Tooltip("Fixes the bushes to drop items correctly rather than spawning undefined items.");
-            UIWidgets::PaddedEnhancementCheckbox("Fix falling from vine edges", "gFixVineFall", true, false); 
-            UIWidgets::Tooltip("Prevents immediately falling off climbable surfaces if climbing on the edges."); 
+            UIWidgets::PaddedEnhancementCheckbox("Fix falling from vine edges", "gFixVineFall", true, false);
+            UIWidgets::Tooltip("Prevents immediately falling off climbable surfaces if climbing on the edges.");
             UIWidgets::PaddedEnhancementCheckbox("Fix Link's eyes open while sleeping", "gFixEyesOpenWhileSleeping", true, false);
             UIWidgets::Tooltip("Fixes Link's eyes being open in the opening cutscene when he is supposed to be sleeping.");
             UIWidgets::PaddedEnhancementCheckbox("Fix Darunia dancing too fast", "gEnhancements.FixDaruniaDanceSpeed",

--- a/soh/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -658,7 +658,7 @@ void func_80AD58D4(EnPoField* this, PlayState* play) {
     if (this->actionTimer != 0) {
         this->actionTimer--;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, play)) {
+    if (!CVarGetInteger("gMMPoeBottling", 0) && Actor_ProcessTalkRequest(&this->actor, play)) {
         EnPoField_SetupInteractWithSoul(this);
         return;
     }
@@ -668,7 +668,15 @@ void func_80AD58D4(EnPoField* this, PlayState* play) {
         EnPoField_SetupSoulDisappear(this);
         return;
     }
-    if (this->collider.base.ocFlags1 & OC1_HIT) {
+    if (CVarGetInteger("gMMPoeBottling", 0)) {
+        // do not collide
+        if (Actor_HasParent(&this->actor, play)) {
+            Actor_Kill(&this->actor);
+        }
+
+        // GI_MAX in this case allows the player to catch the actor in a bottle
+        func_8002F434(&this->actor, play, GI_MAX, 35.0f, 60.0f);
+    } else if (this->collider.base.ocFlags1 & OC1_HIT) {
         this->actor.flags |= ACTOR_FLAG_WILL_TALK;
         func_8002F2F4(&this->actor, play);
     } else {

--- a/soh/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/soh/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -770,7 +770,8 @@ void func_80ADFE80(EnPoh* this, PlayState* play) {
     if (this->unk_198 != 0) {
         this->unk_198--;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, play)) {
+    if (!(CVarGetInteger("gMMPoeBottling", 0) && this->actor.params < EN_POH_SHARP) &&
+        Actor_ProcessTalkRequest(&this->actor, play)) {
         if (this->actor.params >= EN_POH_SHARP) {
             func_80ADE9BC(this);
         } else {
@@ -783,7 +784,15 @@ void func_80ADFE80(EnPoh* this, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_WILL_TALK;
         return;
     }
-    if (this->colliderCyl.base.ocFlags1 & OC1_HIT) {
+    if (CVarGetInteger("gMMPoeBottling", 0) && this->actor.params < EN_POH_SHARP) {
+        if (Actor_HasParent(&this->actor, play)) {
+            Actor_Kill(&this->actor);
+            return;
+        }
+
+        // GI_MAX in this case allows the player to catch the actor in a bottle
+        func_8002F434(&this->actor, play, GI_MAX, 35.0f, 60.0f);
+    } else if (this->colliderCyl.base.ocFlags1 & OC1_HIT) {
         this->actor.flags |= ACTOR_FLAG_WILL_TALK;
         func_8002F2F4(&this->actor, play);
     } else {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13243,6 +13243,8 @@ static BottleCatchInfo D_80854A04[] = {
     { ACTOR_EN_FISH, ITEM_FISH, 0x1F, 0x47 },
     { ACTOR_EN_ICE_HONO, ITEM_BLUE_FIRE, 0x20, 0x5D },
     { ACTOR_EN_INSECT, ITEM_BUG, 0x21, 0x7A },
+    { ACTOR_EN_POH, ITEM_POE, PLAYER_IA_BOTTLE_POE, 0x97 },
+    { ACTOR_EN_PO_FIELD, ITEM_BIG_POE, PLAYER_IA_BOTTLE_BIG_POE, 0xF9 },
 };
 
 void func_8084ECA4(Player* this, PlayState* play) {
@@ -13285,13 +13287,29 @@ void func_8084ECA4(Player* this, PlayState* play) {
 
                     if (this->interactRangeActor != NULL) {
                         catchInfo = &D_80854A04[0];
-                        for (i = 0; i < 4; i++, catchInfo++) {
+                        for (i = 0; i < ARRAY_COUNT(D_80854A04); i++, catchInfo++) {
                             if (this->interactRangeActor->id == catchInfo->actorId) {
                                 break;
                             }
                         }
 
-                        if (i < 4) {
+                        if (catchInfo->actorId == ACTOR_EN_POH || catchInfo->actorId == ACTOR_EN_PO_FIELD) {
+                            // Don't catch Sharp or Flat
+                            // I think they talk to you before you can get in catching range, but might as well prevent it outright
+                            if (catchInfo->actorId == ACTOR_EN_POH && this->interactRangeActor->params >= 2) {
+                                i = ARRAY_COUNT(D_80854A04);
+                            }
+                            // If the catch is a small field Poe (as opposed to a Big Poe), catch a graveyard Poe instead
+                            if (catchInfo->actorId == ACTOR_EN_PO_FIELD && this->interactRangeActor->params == 0) {
+                                i--;
+                                catchInfo--;
+                            }
+                            if (!CVarGetInteger("gMMPoeBottling", 0)) {
+                                i = ARRAY_COUNT(D_80854A04);
+                            }
+                        }
+
+                        if (i < ARRAY_COUNT(D_80854A04)) {
                             this->unk_84F = i + 1;
                             this->unk_850 = 0;
                             this->interactRangeActor->parent = &this->actor;


### PR DESCRIPTION
Adds an option under Enhancements > Gameplay > Items that changes the way catching Poes works to copy Majora's Mask. That is, instead of a prompt opening when you get close to its soul, you just need to swing an empty bottle at it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903425.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903426.zip)
  - [soh-linux-performance.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903427.zip)
  - [soh-mac.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903428.zip)
  - [soh-switch.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903429.zip)
  - [soh-wiiu.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903430.zip)
  - [soh-windows.zip](https://nightly.link/lilDavid/Shipwright/actions/artifacts/1072903431.zip)
<!--- section:artifacts:end -->